### PR TITLE
reset bwMem CPU cache lines

### DIFF
--- a/src/app/pages/server-compare/server-compare.component.ts
+++ b/src/app/pages/server-compare/server-compare.component.ts
@@ -776,6 +776,11 @@ export class ServerCompareComponent implements OnInit, AfterViewInit {
         });
       });
 
+      // reset the annotations
+      if(this.lineChartOptionsBWMem?.plugins?.annotation) {
+        this.lineChartOptionsBWMem.plugins.annotation = {};
+      }
+
       this.lineChartDataBWmem = { labels: chartData.labels, datasets: chartData.datasets };
 
       (this.lineChartOptionsBWMem as any).plugins.tooltip.callbacks.title = function(this: TooltipModel<"line">, tooltipItems: TooltipItem<"line">[]) {

--- a/src/app/pages/server-details/server-details.component.ts
+++ b/src/app/pages/server-details/server-details.component.ts
@@ -877,6 +877,8 @@ export class ServerDetailsComponent implements OnInit, OnDestroy {
           this.lineChartOptionsBWMem.plugins.annotation = {
             annotations: annotations
           };
+        } else {
+          this.lineChartOptionsBWMem.plugins.annotation = {};
         }
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved chart rendering by ensuring annotations are reset before new data is processed, preventing visual artifacts.
	- Enhanced stability of the server details view by ensuring the annotation property is always defined, reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->