### PR TITLE
block gptbot due to high rps and invalid spamming

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,3 +1,7 @@
+# spamming our site with messed up (e.g. recursive paths in static assets) queries at 5 requests/sec
+User-agent: GPTBot
+Disallow: /
+
 User-agent: *
 Allow: /
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a directive in the robots.txt file to disallow access for GPTBot, enhancing control over site crawling and indexing.
  
- **Bug Fixes**
	- Addressed potential issues related to excessive requests from GPTBot by restricting its access to the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->