### PR TITLE
switch from calendly link to neeto-cal embed

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { HeaderComponent } from './layout/header/header.component';
 import { FooterComponent } from './layout/footer/footer.component';
 import { AnalyticsService } from './services/analytics.service';
 import { Subscription } from 'rxjs';
+import { NeetoCalService } from './services/neeto-cal.service';
 
 @Component({
   selector: 'app-root',
@@ -27,7 +28,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     @Inject(DOCUMENT) private document: Document,
     private router: Router,
     private analytics: AnalyticsService,
-    private metaTagService: Meta) {
+    private metaTagService: Meta,
+    private neetoCalService: NeetoCalService) {
 
     this.subscription.add(
       router.events.subscribe( (event: Event) => {
@@ -74,6 +76,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     register();
+    this.neetoCalService.initialize();
   }
 
   ngAfterViewInit(): void {

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -32,14 +32,12 @@
                 </div>
               </li>
               <li class="py-1">
-                <a class="navbar_link" href="https://calendly.com/spare-cores/30min" target="_blank" data-ph-capture-attribute-sc-event="schedule demo">
-                  <button
-                    id="demo_button"
-                    class="text-white bg-emerald-400 hover:bg-emerald-500 rounded-lg px-3 py-2 relative flex gap-2 items-center">
-                    <lucide-icon class="h-4 w-4" name="calendar-days"></lucide-icon>
-                    Book a Demo
-                  </button>
-                </a>
+                <button
+                  id="header-demo-button"
+                  class="text-white bg-emerald-400 hover:bg-emerald-500 rounded-lg px-3 py-2 relative flex gap-2 items-center">
+                  <lucide-icon class="h-4 w-4" name="calendar-days"></lucide-icon>
+                  Book a Demo
+                </button>
               </li>
               <li [ngClass]="
                     {'hidden' : compareCount() === 0}"
@@ -175,8 +173,6 @@
     </li>
   </ul>
 </div>
-
-
 
 <div id="compare_options" class="z-10 hidden bg-secondary rounded-lg shadow w-250 border border-emerald-400 border-solid">
   <ul

--- a/src/app/pages/landingpage/landingpage.component.html
+++ b/src/app/pages/landingpage/landingpage.component.html
@@ -35,9 +35,7 @@
             </div>
           </div>
           <div class="flex gap-8 justify-center lg:justify-start">
-            <a href="https://calendly.com/spare-cores/30min" target="_blank" rel="noopener" data-ph-capture-attribute-sc-event="schedule demo">
-              <button class="btn-primary py-5 px-5">Book a Demo</button>
-            </a>
+            <button id="landing-demo-button" class="btn-primary py-5 px-5">Book a Demo</button>
             <button class="bg-transparent text-teal-500 py-5 px-5 font-bold hover:text-teal-600" routerLink="/servers">Navigate Server Options and Prices ></button>
           </div>
         </div>

--- a/src/app/services/neeto-cal.service.ts
+++ b/src/app/services/neeto-cal.service.ts
@@ -14,8 +14,8 @@ export class NeetoCalService {
       return;
     }
     (window as any).neetoCal = (window as any).neetoCal || {
-      embed: function() {
-        ((window as any).neetoCal.q = (window as any).neetoCal.q || []).push(arguments);
+      embed: function(...args: any[]) {
+        ((window as any).neetoCal.q = (window as any).neetoCal.q || []).push(args);
       }
     };
     if (!this.isScriptLoaded) {

--- a/src/app/services/neeto-cal.service.ts
+++ b/src/app/services/neeto-cal.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NeetoCalService {
+  private isScriptLoaded = false;
+
+  constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
+  initialize(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    (window as any).neetoCal = (window as any).neetoCal || {
+      embed: function() {
+        ((window as any).neetoCal.q = (window as any).neetoCal.q || []).push(arguments);
+      }
+    };
+    if (!this.isScriptLoaded) {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = 'https://cdn.neetocal.com/javascript/embed.js';
+      script.onload = () => {
+        this.isScriptLoaded = true;
+        this.initializeButtons();
+      };
+      document.head.appendChild(script);
+    } else {
+      this.initializeButtons();
+    }
+  }
+
+  private initializeButtons(): void {
+    // need to call the embed function for each button
+    const buttonSelectors = [
+      '#header-demo-button',
+      '#landing-demo-button'
+    ];
+    buttonSelectors.forEach(selector => {
+      if (document.querySelector(selector)) {
+        (window as any).neetoCal.embed({
+          type: "elementClick",
+          id: "7c3c0ad8-812b-423f-b064-0ea44d527368",
+          organization: "sparecores",
+          elementSelector: selector,
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated NeetoCal scheduling widget, allowing users to book demos directly from the header and landing page buttons.

- **Style**
	- Updated "Book a Demo" buttons on the header and landing page for improved consistency and accessibility. The buttons now use unique IDs and no longer include direct external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->