### PR TITLE
Dev 672 make slot machine iconstexts clickable

### DIFF
--- a/cypress/e2e/slot-machine-links.cy.ts
+++ b/cypress/e2e/slot-machine-links.cy.ts
@@ -185,8 +185,8 @@ describe("Landing page slot machine links", () => {
     cy.visit("http://localhost:4200/");
     cy.wait("@searchServerPrices");
 
-    cy.get("#cpuCount").clear().type("8");
-    cy.get("#ramCount").clear().type("32");
+    cy.get("#cpuCount").clear().type("8").should("have.value", "8");
+    cy.get("#ramCount").clear().type("32").should("have.value", "32");
 
     cy.get("#slot_vendor_link", { timeout: 10000 })
       .should("have.attr", "href")

--- a/cypress/e2e/slot-machine-links.cy.ts
+++ b/cypress/e2e/slot-machine-links.cy.ts
@@ -1,0 +1,205 @@
+describe("Landing page slot machine links", () => {
+  const serverPricesResponse = [
+    {
+      vendor_id: "aws",
+      region_id: "us-east-1",
+      zone_id: "use1-az1",
+      server_id: "m7g.large",
+      operating_system: "Linux",
+      allocation: "ondemand",
+      unit: "hour",
+      price: 0.12,
+      price_upfront: 0,
+      price_tiered: [],
+      currency: "USD",
+      status: "active",
+      observed_at: "2026-04-08T08:32:05",
+      vendor: {
+        vendor_id: "aws",
+        name: "Amazon Web Services",
+        logo: "/assets/images/vendors/aws.svg",
+        homepage: "https://aws.amazon.com",
+        country_id: "US",
+        city: "Seattle",
+        state: "Washington",
+        address_line: "410 Terry Ave N",
+        zip_code: "98109",
+        founding_year: 2002,
+        status: "active",
+        observed_at: "2026-04-08T09:08:45.469297",
+      },
+      region: {
+        vendor_id: "aws",
+        region_id: "us-east-1",
+        name: "US East (N. Virginia)",
+        api_reference: "us-east-1",
+        display_name: "US East (N. Virginia)",
+        country_id: "US",
+        status: "active",
+        observed_at: "2026-04-08T07:41:06.557719",
+      },
+      zone: {
+        vendor_id: "aws",
+        region_id: "us-east-1",
+        zone_id: "use1-az1",
+        name: "us-east-1a",
+        api_reference: "us-east-1a",
+        display_name: "us-east-1a",
+        status: "active",
+        observed_at: "2026-04-08T07:46:15.578745",
+      },
+      server: {
+        vendor_id: "aws",
+        server_id: "m7g.large",
+        name: "m7g.large",
+        api_reference: "m7g.large",
+        display_name: "m7g.large",
+        description: "AWS Graviton instance",
+        cpu_architecture: "arm64",
+      },
+    },
+    {
+      vendor_id: "gcp",
+      region_id: "us-central1",
+      zone_id: "us-central1-a",
+      server_id: "n2-standard-2",
+      operating_system: "Linux",
+      allocation: "ondemand",
+      unit: "hour",
+      price: 0.16,
+      price_upfront: 0,
+      price_tiered: [],
+      currency: "USD",
+      status: "active",
+      observed_at: "2026-04-08T08:32:05",
+      vendor: {
+        vendor_id: "gcp",
+        name: "Google Cloud",
+        logo: "/assets/images/vendors/gcp.svg",
+        homepage: "https://cloud.google.com",
+        country_id: "US",
+        city: "Mountain View",
+        state: "California",
+        address_line: "1600 Amphitheatre Parkway",
+        zip_code: "94043",
+        founding_year: 2008,
+        status: "active",
+        observed_at: "2026-04-08T09:08:45.469297",
+      },
+      region: {
+        vendor_id: "gcp",
+        region_id: "us-central1",
+        name: "Iowa",
+        api_reference: "us-central1",
+        display_name: "Iowa",
+        country_id: "US",
+        status: "active",
+        observed_at: "2026-04-08T07:41:06.557719",
+      },
+      zone: {
+        vendor_id: "gcp",
+        region_id: "us-central1",
+        zone_id: "us-central1-a",
+        name: "us-central1-a",
+        api_reference: "us-central1-a",
+        display_name: "us-central1-a",
+        status: "active",
+        observed_at: "2026-04-08T07:46:15.578745",
+      },
+      server: {
+        vendor_id: "gcp",
+        server_id: "n2-standard-2",
+        name: "n2-standard-2",
+        api_reference: "n2-standard-2",
+        display_name: "n2-standard-2",
+        description: "General purpose machine",
+        cpu_architecture: "x86_64",
+      },
+    },
+    {
+      vendor_id: "hcloud",
+      region_id: "eu-central",
+      zone_id: "nbg1-dc3",
+      server_id: "cx22",
+      operating_system: "Linux",
+      allocation: "ondemand",
+      unit: "hour",
+      price: 0.2,
+      price_upfront: 0,
+      price_tiered: [],
+      currency: "USD",
+      status: "active",
+      observed_at: "2026-04-08T08:32:05",
+      vendor: {
+        vendor_id: "hcloud",
+        name: "Hetzner Cloud",
+        logo: "/assets/images/vendors/hcloud.svg",
+        homepage: "https://www.hetzner.com/cloud",
+        country_id: "DE",
+        city: "Gunzenhausen",
+        state: "Bavaria",
+        address_line: "Industriestr. 25",
+        zip_code: "91710",
+        founding_year: 1997,
+        status: "active",
+        observed_at: "2026-04-08T09:08:45.469297",
+      },
+      region: {
+        vendor_id: "hcloud",
+        region_id: "eu-central",
+        name: "Nuremberg",
+        api_reference: "eu-central",
+        display_name: "Nuremberg",
+        country_id: "DE",
+        status: "active",
+        observed_at: "2026-04-08T07:41:06.557719",
+      },
+      zone: {
+        vendor_id: "hcloud",
+        region_id: "eu-central",
+        zone_id: "nbg1-dc3",
+        name: "nbg1-dc3",
+        api_reference: "nbg1-dc3",
+        display_name: "nbg1-dc3",
+        status: "active",
+        observed_at: "2026-04-08T07:46:15.578745",
+      },
+      server: {
+        vendor_id: "hcloud",
+        server_id: "cx22",
+        name: "cx22",
+        api_reference: "cx22",
+        display_name: "cx22",
+        description: "Shared vCPU instance",
+        cpu_architecture: "x86_64",
+      },
+    },
+  ];
+
+  it("makes the settled vendor, server, and region entries clickable", () => {
+    cy.intercept("GET", "**/server_prices*", {
+      statusCode: 200,
+      body: serverPricesResponse,
+    }).as("searchServerPrices");
+
+    cy.visit("http://localhost:4200/");
+    cy.wait("@searchServerPrices");
+
+    cy.get("#cpuCount").clear().type("8");
+    cy.get("#ramCount").clear().type("32");
+
+    cy.get("#slot_vendor_link", { timeout: 10000 })
+      .should("have.attr", "href")
+      .and("include", "/servers?vendor=aws")
+      .and("include", "vcpus_min=8")
+      .and("include", "memory_min=32");
+    cy.get("#slot_server_link")
+      .should("have.attr", "href")
+      .and("include", "/server/aws/m7g.large");
+    cy.get("#slot_region_link")
+      .should("have.attr", "href")
+      .and("include", "/servers?vendor_regions=aws~us-east-1")
+      .and("include", "vcpus_min=8")
+      .and("include", "memory_min=32");
+  });
+});

--- a/src/app/pages/landingpage/landingpage.component.html
+++ b/src/app/pages/landingpage/landingpage.component.html
@@ -121,21 +121,45 @@
                       class="slot flex flex-col align-center"
                       [style]="getStyle(i)"
                     >
-                      <div class="slot_inner" [style]="getInnerStyle(i)">
-                        @if (!spinnerItem.logo) {
-                          <div class="text-center font-bold text-3xl">
-                            {{ spinnerItem.name }}
-                          </div>
-                        }
-                        @if (spinnerItem.logo) {
-                          <img
-                            [src]="spinnerItem.logo"
-                            style="margin: 0.5rem"
-                            class="rounded-lg"
-                            alt="{{ spinnerItem.name }} logo"
-                          />
-                        }
-                      </div>
+                      @if (isSlotLinkActive(i) && hasVendorLink(spinnerItem)) {
+                        <a
+                          id="slot_vendor_link"
+                          class="slot_inner slot_link"
+                          [style]="getInnerStyle(i)"
+                          routerLink="/servers"
+                          [queryParams]="getVendorQueryParams(spinnerItem)"
+                        >
+                          @if (!spinnerItem.logo) {
+                            <div class="text-center font-bold text-3xl">
+                              {{ spinnerItem.name }}
+                            </div>
+                          }
+                          @if (spinnerItem.logo) {
+                            <img
+                              [src]="spinnerItem.logo"
+                              style="margin: 0.5rem"
+                              class="rounded-lg"
+                              alt="{{ spinnerItem.name }} logo"
+                            />
+                          }
+                        </a>
+                      } @else {
+                        <div class="slot_inner" [style]="getInnerStyle(i)">
+                          @if (!spinnerItem.logo) {
+                            <div class="text-center font-bold text-3xl">
+                              {{ spinnerItem.name }}
+                            </div>
+                          }
+                          @if (spinnerItem.logo) {
+                            <img
+                              [src]="spinnerItem.logo"
+                              style="margin: 0.5rem"
+                              class="rounded-lg"
+                              alt="{{ spinnerItem.name }} logo"
+                            />
+                          }
+                        </div>
+                      }
                     </div>
                   }
                 </div>
@@ -157,21 +181,44 @@
                       class="slot flex flex-col align-center"
                       [style]="getStyle(i)"
                     >
-                      <div class="slot_inner" [style]="getInnerStyle(i)">
-                        <div
-                          class="text-center font-bold overflow-hidden"
-                          style="text-overflow: ellipsis"
-                          [ngClass]="{
-                            'text-xl': spinnerItem.name.length < 13,
-                            'text-md': spinnerItem.name.length >= 13,
-                          }"
+                      @if (isSlotLinkActive(i) && hasServerLink(spinnerItem)) {
+                        <a
+                          id="slot_server_link"
+                          class="slot_inner slot_link"
+                          [style]="getInnerStyle(i)"
+                          [routerLink]="getServerRouteCommands(spinnerItem)"
                         >
-                          {{ spinnerItem.name }}
+                          <div
+                            class="text-center font-bold overflow-hidden"
+                            style="text-overflow: ellipsis"
+                            [ngClass]="{
+                              'text-xl': spinnerItem.name.length < 13,
+                              'text-md': spinnerItem.name.length >= 13,
+                            }"
+                          >
+                            {{ spinnerItem.name }}
+                          </div>
+                          <div class="text-center">
+                            {{ spinnerItem.architecture }}
+                          </div>
+                        </a>
+                      } @else {
+                        <div class="slot_inner" [style]="getInnerStyle(i)">
+                          <div
+                            class="text-center font-bold overflow-hidden"
+                            style="text-overflow: ellipsis"
+                            [ngClass]="{
+                              'text-xl': spinnerItem.name.length < 13,
+                              'text-md': spinnerItem.name.length >= 13,
+                            }"
+                          >
+                            {{ spinnerItem.name }}
+                          </div>
+                          <div class="text-center">
+                            {{ spinnerItem.architecture }}
+                          </div>
                         </div>
-                        <div class="text-center">
-                          {{ spinnerItem.architecture }}
-                        </div>
-                      </div>
+                      }
                     </div>
                   }
                 </div>
@@ -193,19 +240,41 @@
                       class="slot flex flex-col align-center"
                       [style]="getStyle(i)"
                     >
-                      <div class="slot_inner" [style]="getInnerStyle(i)">
-                        <div
-                          class="text-center font-bold overflow-hidden"
-                          style="text-overflow: ellipsis"
-                          [ngClass]="{
-                            'text-xl': spinnerItem.name.length < 13,
-                            'text-md': spinnerItem.name.length >= 13,
-                          }"
+                      @if (isSlotLinkActive(i) && hasRegionLink(spinnerItem)) {
+                        <a
+                          id="slot_region_link"
+                          class="slot_inner slot_link"
+                          [style]="getInnerStyle(i)"
+                          routerLink="/servers"
+                          [queryParams]="getRegionQueryParams(spinnerItem)"
                         >
-                          {{ spinnerItem.name }}
+                          <div
+                            class="text-center font-bold overflow-hidden"
+                            style="text-overflow: ellipsis"
+                            [ngClass]="{
+                              'text-xl': spinnerItem.name.length < 13,
+                              'text-md': spinnerItem.name.length >= 13,
+                            }"
+                          >
+                            {{ spinnerItem.name }}
+                          </div>
+                          <div class="text-center">{{ spinnerItem.city }}</div>
+                        </a>
+                      } @else {
+                        <div class="slot_inner" [style]="getInnerStyle(i)">
+                          <div
+                            class="text-center font-bold overflow-hidden"
+                            style="text-overflow: ellipsis"
+                            [ngClass]="{
+                              'text-xl': spinnerItem.name.length < 13,
+                              'text-md': spinnerItem.name.length >= 13,
+                            }"
+                          >
+                            {{ spinnerItem.name }}
+                          </div>
+                          <div class="text-center">{{ spinnerItem.city }}</div>
                         </div>
-                        <div class="text-center">{{ spinnerItem.city }}</div>
-                      </div>
+                      }
                     </div>
                   }
                 </div>

--- a/src/app/pages/landingpage/landingpage.component.scss
+++ b/src/app/pages/landingpage/landingpage.component.scss
@@ -193,6 +193,22 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
+
+      &.slot_link {
+        text-decoration: none;
+        color: inherit;
+        cursor: pointer;
+        transition:
+          box-shadow 150ms ease-in-out,
+          transform 150ms ease-in-out;
+
+        &:hover,
+        &:focus-visible {
+          box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.55);
+          transform: scale(1.01);
+          outline: none;
+        }
+      }
     }
   }
 

--- a/src/app/pages/landingpage/landingpage.component.spec.ts
+++ b/src/app/pages/landingpage/landingpage.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { PLATFORM_ID } from "@angular/core";
 
 import { LandingpageComponent } from "./landingpage.component";
 import { sharedTestingProviders } from "../../../testing/testbed.providers";
@@ -10,15 +11,98 @@ describe("LandingpageComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LandingpageComponent],
-      providers: [...sharedTestingProviders],
+      providers: [
+        ...sharedTestingProviders,
+        {
+          provide: PLATFORM_ID,
+          useValue: "server",
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LandingpageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render vendor, server, and region links for the settled front slot", async () => {
+    component.hasRealValues = true;
+    component.isSpinning = false;
+    component.cpuCount = 8;
+    component.ramCount = 32;
+    component.spinnerContents[0][0] = {
+      name: "AWS",
+      logo: "/assets/images/vendors/aws.svg",
+      vendorId: "aws",
+    };
+    component.spinnerContents[1][0] = {
+      name: "m7g.large",
+      architecture: "arm64",
+      vendorId: "aws",
+      apiReference: "m7g.large",
+    };
+    component.spinnerContents[2][0] = {
+      name: "US East (N. Virginia)",
+      city: "us-east-1a",
+      vendorId: "aws",
+      regionId: "us-east-1",
+      zoneId: "use1-az1",
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const vendorLink = host.querySelector(
+      "#slot_vendor_link",
+    ) as HTMLAnchorElement;
+    const serverLink = host.querySelector(
+      "#slot_server_link",
+    ) as HTMLAnchorElement;
+    const regionLink = host.querySelector(
+      "#slot_region_link",
+    ) as HTMLAnchorElement;
+
+    expect(vendorLink.getAttribute("href")).toContain("/servers?vendor=aws");
+    expect(vendorLink.getAttribute("href")).toContain("vcpus_min=8");
+    expect(vendorLink.getAttribute("href")).toContain("memory_min=32");
+    expect(serverLink.getAttribute("href")).toContain("/server/aws/m7g.large");
+    expect(regionLink.getAttribute("href")).toContain(
+      "/servers?vendor_regions=aws~us-east-1",
+    );
+    expect(regionLink.getAttribute("href")).toContain("vcpus_min=8");
+    expect(regionLink.getAttribute("href")).toContain("memory_min=32");
+  });
+
+  it("should normalize landing-page server listing query params", () => {
+    component.cpuCount = 0;
+    component.ramCount = 999;
+
+    expect(
+      component.getVendorQueryParams({ name: "AWS", vendorId: "aws" }),
+    ).toEqual({
+      vendor: "aws",
+      vcpus_min: 2,
+      memory_min: component.MAX_RAM_COUNT,
+    });
+  });
+
+  it("should keep slot links inactive while spinning or off the front face", () => {
+    component.isSpinning = true;
+    component.hasRealValues = true;
+
+    expect(component.isSlotLinkActive(0)).toBeFalse();
+
+    component.isSpinning = false;
+
+    expect(component.isSlotLinkActive(1)).toBeFalse();
+    expect(component.isSlotLinkActive(0)).toBeTrue();
   });
 });

--- a/src/app/pages/landingpage/landingpage.component.spec.ts
+++ b/src/app/pages/landingpage/landingpage.component.spec.ts
@@ -70,6 +70,16 @@ describe("LandingpageComponent", () => {
       "#slot_region_link",
     ) as HTMLAnchorElement;
 
+    expect(vendorLink)
+      .withContext("Expected #slot_vendor_link to be rendered")
+      .not.toBeNull();
+    expect(serverLink)
+      .withContext("Expected #slot_server_link to be rendered")
+      .not.toBeNull();
+    expect(regionLink)
+      .withContext("Expected #slot_region_link to be rendered")
+      .not.toBeNull();
+
     expect(vendorLink.getAttribute("href")).toContain("/servers?vendor=aws");
     expect(vendorLink.getAttribute("href")).toContain("vcpus_min=8");
     expect(vendorLink.getAttribute("href")).toContain("memory_min=32");

--- a/src/app/pages/landingpage/landingpage.component.ts
+++ b/src/app/pages/landingpage/landingpage.component.ts
@@ -22,6 +22,14 @@ import { SearchServerPricesServerPricesGetData } from "../../../../sdk/data-cont
 import { AnalyticsService } from "../../services/analytics.service";
 import { NeetoCalService } from "../../services/neeto-cal.service";
 import { PrismService } from "../../services/prism.service";
+import {
+  SlotMachineContents,
+  SlotMachineRegionItem,
+  SlotMachineServerItem,
+  SlotMachineServerListingQuery,
+  SlotMachineServerPrice,
+  SlotMachineVendorItem,
+} from "./landingpage.types";
 
 @Component({
   selector: "app-landingpage",
@@ -52,7 +60,7 @@ export class LandingpageComponent implements OnInit, AfterViewInit {
   cpuCount = 2;
   ramCount = 4;
 
-  spinnerContents: any = spinner_initial_data;
+  spinnerContents = spinner_initial_data as SlotMachineContents;
   SPINNER_COUNT = 36;
   SPINNER_RADIUS = 780;
   MAX_CPU_COUNT = 128;
@@ -188,21 +196,88 @@ export class LandingpageComponent implements OnInit, AfterViewInit {
     return "background: rgba(255,255,255,1) !important; color: #000 !important;";
   }
 
+  isSlotLinkActive(index: number) {
+    return index === 0 && !this.isSpinning && this.hasRealValues;
+  }
+
+  hasVendorLink(item: SlotMachineVendorItem) {
+    return Boolean(item.vendorId);
+  }
+
+  hasServerLink(item: SlotMachineServerItem) {
+    return Boolean(item.vendorId && item.apiReference);
+  }
+
+  hasRegionLink(item: SlotMachineRegionItem) {
+    return Boolean(item.vendorId && item.regionId);
+  }
+
+  private getNormalizedCpuCount(value: number) {
+    if (Number.isNaN(value) || !value || value < 1) {
+      return 2;
+    }
+
+    return Math.min(value, this.MAX_CPU_COUNT);
+  }
+
+  private getNormalizedRamCount(value: number) {
+    if (Number.isNaN(value) || !value || value < 0.1) {
+      return 4;
+    }
+
+    return Math.min(value, this.MAX_RAM_COUNT);
+  }
+
+  private getServerListingFilters() {
+    return {
+      vcpus_min: this.getNormalizedCpuCount(this.cpuCount),
+      memory_min: this.getNormalizedRamCount(this.ramCount),
+    };
+  }
+
+  private getServerListingQuery(
+    query: Pick<SlotMachineServerListingQuery, "vendor" | "vendor_regions">,
+  ): SlotMachineServerListingQuery {
+    return {
+      ...query,
+      ...this.getServerListingFilters(),
+    };
+  }
+
+  getVendorQueryParams(item: SlotMachineVendorItem) {
+    return item.vendorId
+      ? this.getServerListingQuery({ vendor: item.vendorId })
+      : null;
+  }
+
+  getServerRouteCommands(item: SlotMachineServerItem) {
+    if (!item.vendorId || !item.apiReference) {
+      return null;
+    }
+
+    return ["/server", item.vendorId, item.apiReference];
+  }
+
+  getRegionQueryParams(item: SlotMachineRegionItem) {
+    if (!item.vendorId || !item.regionId) {
+      return null;
+    }
+
+    return this.getServerListingQuery({
+      vendor_regions: this.buildVendorRegionFilter(
+        item.vendorId,
+        item.regionId,
+      ),
+    });
+  }
+
+  private buildVendorRegionFilter(vendorId: string, regionId: string) {
+    return `${vendorId}~${regionId}`;
+  }
+
   spinClicked() {
-    if (Number.isNaN(this.cpuCount) || !this.cpuCount || this.cpuCount < 1) {
-      this.cpuCount = 2;
-    }
-
-    if (Number.isNaN(this.ramCount) || !this.ramCount || this.ramCount < 0.1) {
-      this.ramCount = 4;
-    }
-
-    if (this.cpuCount > this.MAX_CPU_COUNT) {
-      this.cpuCount = this.MAX_CPU_COUNT;
-    }
-    if (this.ramCount > this.MAX_RAM_COUNT) {
-      this.ramCount = this.MAX_RAM_COUNT;
-    }
+    this.cpuCount = this.getNormalizedCpuCount(this.cpuCount);
+    this.ramCount = this.getNormalizedRamCount(this.ramCount);
 
     const spinButton = document.getElementById("spin_button");
     if (spinButton) {
@@ -302,17 +377,25 @@ export class LandingpageComponent implements OnInit, AfterViewInit {
       }
 
       indices.forEach((index, i) => {
+        const serverPrice = top3server[i] as SlotMachineServerPrice;
+
         this.spinnerContents[0][index] = {
-          name: top3server[i].vendor.vendor_id.toString().toUpperCase(),
-          logo: top3server[i].vendor.logo,
+          name: serverPrice.vendor.vendor_id.toString().toUpperCase(),
+          logo: serverPrice.vendor.logo,
+          vendorId: serverPrice.vendor.vendor_id,
         };
         this.spinnerContents[1][index] = {
-          name: top3server[i].server.display_name,
-          architecture: top3server[i].server.cpu_architecture,
+          name: serverPrice.server.display_name,
+          architecture: serverPrice.server.cpu_architecture,
+          vendorId: serverPrice.server.vendor_id,
+          apiReference: serverPrice.server.api_reference,
         };
         this.spinnerContents[2][index] = {
-          name: top3server[i].region?.display_name,
-          city: top3server[i].zone?.display_name,
+          name: serverPrice.region?.display_name || serverPrice.region_id,
+          city: serverPrice.zone?.display_name,
+          vendorId: serverPrice.region?.vendor_id || serverPrice.vendor_id,
+          regionId: serverPrice.region_id,
+          zoneId: serverPrice.zone_id,
         };
       });
     }, 200);

--- a/src/app/pages/landingpage/landingpage.component.ts
+++ b/src/app/pages/landingpage/landingpage.component.ts
@@ -27,7 +27,6 @@ import {
   SlotMachineRegionItem,
   SlotMachineServerItem,
   SlotMachineServerListingQuery,
-  SlotMachineServerPrice,
   SlotMachineVendorItem,
 } from "./landingpage.types";
 
@@ -377,7 +376,10 @@ export class LandingpageComponent implements OnInit, AfterViewInit {
       }
 
       indices.forEach((index, i) => {
-        const serverPrice = top3server[i] as SlotMachineServerPrice;
+        const serverPrice = top3server[i];
+        if (!serverPrice) {
+          return;
+        }
 
         this.spinnerContents[0][index] = {
           name: serverPrice.vendor.vendor_id.toString().toUpperCase(),

--- a/src/app/pages/landingpage/landingpage.types.ts
+++ b/src/app/pages/landingpage/landingpage.types.ts
@@ -1,0 +1,38 @@
+import { SearchServerPricesServerPricesGetData } from "../../../../sdk/data-contracts";
+
+export type SlotMachineVendorItem = {
+  name: string;
+  logo?: string | null;
+  vendorId?: string;
+};
+
+export type SlotMachineServerItem = {
+  name: string;
+  architecture?: string;
+  vendorId?: string;
+  apiReference?: string;
+};
+
+export type SlotMachineRegionItem = {
+  name: string;
+  city?: string;
+  vendorId?: string;
+  regionId?: string;
+  zoneId?: string;
+};
+
+export type SlotMachineContents = [
+  SlotMachineVendorItem[],
+  SlotMachineServerItem[],
+  SlotMachineRegionItem[],
+];
+
+export type SlotMachineServerPrice =
+  SearchServerPricesServerPricesGetData[number];
+
+export type SlotMachineServerListingQuery = {
+  vendor?: string;
+  vendor_regions?: string;
+  vcpus_min: number;
+  memory_min: number;
+};

--- a/src/app/pages/regions/regions.component.html
+++ b/src/app/pages/regions/regions.component.html
@@ -101,8 +101,10 @@
             <td>
               <div class="flex justify-end" (click)="$event.stopPropagation()">
                 <a
-                  routerLink="/server_prices"
-                  [queryParams]="{ regions: region.region_id }"
+                  routerLink="/servers"
+                  [queryParams]="{
+                    vendor_regions: getVendorRegionFilter(region),
+                  }"
                 >
                   <lucide-icon
                     name="chevron-right"

--- a/src/app/pages/regions/regions.component.spec.ts
+++ b/src/app/pages/regions/regions.component.spec.ts
@@ -1,24 +1,68 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { PLATFORM_ID } from "@angular/core";
+import { Router } from "@angular/router";
 
 import { RegionsComponent as RegionsComponent } from "./regions.component";
 import { sharedTestingProviders } from "../../../testing/testbed.providers";
+import { KeeperAPIService } from "../../services/keeper-api.service";
 
 describe("RegionsComponent", () => {
+  const keeperApiService = {
+    getRegions: jasmine.createSpy("getRegions"),
+    getVendors: jasmine.createSpy("getVendors"),
+  };
+
   let component: RegionsComponent;
   let fixture: ComponentFixture<RegionsComponent>;
+  let router: Router;
 
   beforeEach(async () => {
+    keeperApiService.getRegions.and.resolveTo({ body: [] });
+    keeperApiService.getVendors.and.resolveTo({ body: [] });
+
     await TestBed.configureTestingModule({
       imports: [RegionsComponent],
-      providers: [...sharedTestingProviders],
+      providers: [
+        ...sharedTestingProviders,
+        {
+          provide: PLATFORM_ID,
+          useValue: "server",
+        },
+        {
+          provide: KeeperAPIService,
+          useValue: keeperApiService,
+        },
+      ],
     }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, "navigate");
 
     fixture = TestBed.createComponent(RegionsComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should build vendor region filters for the servers page", () => {
+    expect(
+      component.getVendorRegionFilter({
+        vendor_id: "aws",
+        region_id: "us-east-1",
+      } as any),
+    ).toBe("aws~us-east-1");
+  });
+
+  it("should route region clicks to the servers page with vendor_regions", () => {
+    component.openLink({ vendor_id: "aws", region_id: "us-east-1" });
+
+    expect(router.navigate).toHaveBeenCalledWith(["/servers"], {
+      queryParams: { vendor_regions: "aws~us-east-1" },
+    });
   });
 });

--- a/src/app/pages/regions/regions.component.ts
+++ b/src/app/pages/regions/regions.component.ts
@@ -84,6 +84,10 @@ export class RegionsComponent implements OnInit {
 
   bubble_map: any;
 
+  getVendorRegionFilter(item: TableRegionTableRegionGetData[number]) {
+    return `${item.vendor_id}~${item.region_id}`;
+  }
+
   ngOnInit() {
     this.SEOHandler.updateTitleAndMetaTags(
       "Regions - Spare Cores",
@@ -254,7 +258,9 @@ export class RegionsComponent implements OnInit {
   }
 
   openLink(item: any) {
-    this.router.navigateByUrl(`/server_prices?regions=${item.region_id}`);
+    this.router.navigate(["/servers"], {
+      queryParams: { vendor_regions: this.getVendorRegionFilter(item) },
+    });
   }
 
   toggleVendorSelected(vendorId: string) {

--- a/src/app/tools/spinner_initial_data.ts
+++ b/src/app/tools/spinner_initial_data.ts
@@ -1,4 +1,6 @@
-export const spinner_initial_data = [
+import { SlotMachineContents } from "../pages/landingpage/landingpage.types";
+
+export const spinner_initial_data: SlotMachineContents = [
   [
     {
       name: "AWS",


### PR DESCRIPTION
# Overview

Slot machine results now point to the related Vendor/Server/Zone with the user's CPU and RAM (GB) selection!
Also fixed the By Region page's links to point to the corresponding servers instead server prices page. 

## Required checks

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

Required checks before asking for human review:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and brief description or reference to the relevant issue with details
- [x] All PR builders passed (linter, unit tests, e2e tests, visual regression tests)
- [x] Manual testing of new features or bugfixes along with affected pages or components
- [x] Redundant AI comments, unwanted complexity, and unintentional drifts cleaned up

Further required checks after all other major items in this list are completed:

- [x] No red flags from coderabbit.ai
- [x] Human approval


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slot machine rings (vendor, server, region) are interactive and clickable, enabling direct navigation to filtered server listings.
  * Hover/focus visual feedback added (subtle scale and focus ring).

* **Updates**
  * Navigation now uses a unified server-filtering approach (vendor/region filters and listing query params).
  * CPU/RAM inputs are normalized/clamped for consistent search behavior.

* **Tests**
  * Added end-to-end test coverage for slot links and expanded unit tests for navigation and input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->