### PR TITLE
fix advisor price baseline when traffic/storage requirements are present

### DIFF
--- a/src/app/pages/advisor/advisor.component.spec.ts
+++ b/src/app/pages/advisor/advisor.component.spec.ts
@@ -1564,6 +1564,95 @@ describe("AdvisorComponent", () => {
     expect(priceDelta.classList).toContain("advisor-table-delta--positive");
   }));
 
+  it("uses addon-inclusive baseline pricing for price deltas when traffic or storage requirements are set", fakeAsync(() => {
+    searchServers.and.callFake(
+      (query: {
+        partial_name_or_id?: string | null;
+        vendor?: string | null;
+        extra_storage_size?: number | null;
+      }) => {
+        if (
+          query.partial_name_or_id === "large" &&
+          query.vendor === "aws" &&
+          query.extra_storage_size === 100
+        ) {
+          return Promise.resolve({
+            body: [
+              {
+                vendor_id: "aws",
+                api_reference: "large",
+                display_name: "large",
+                server_id: "srv-baseline",
+                min_price: 0.1,
+                min_price_ondemand: 0.1,
+              },
+            ],
+            headers: {
+              get: (name: string) => (name === "x-total-count" ? "1" : null),
+            },
+          });
+        }
+
+        if (query.partial_name_or_id === "large" && query.vendor === "aws") {
+          return Promise.resolve({
+            body: [
+              {
+                vendor_id: "aws",
+                api_reference: "large",
+                display_name: "large",
+                server_id: "srv-baseline",
+                score: 100,
+                score_per_price: 50,
+              },
+            ],
+            headers: {
+              get: (name: string) => (name === "x-total-count" ? "1" : null),
+            },
+          });
+        }
+
+        return Promise.resolve({
+          body: [
+            {
+              vendor_id: "aws",
+              api_reference: "c7a.large",
+              display_name: "c7a.large",
+              server_id: "srv-1",
+            },
+          ],
+          headers: {
+            get: (name: string) => (name === "x-total-count" ? "1" : null),
+          },
+        });
+      },
+    );
+
+    selectBaselineServer();
+    flushMicrotasks();
+    fixture.detectChanges();
+
+    component.query.set({ extra_storage_size: "100" });
+    fixture.detectChanges();
+    flushMicrotasks();
+    fixture.detectChanges();
+
+    expect(component.baselinePriceAggregate().min_price).toBe(0.1);
+
+    const priceDelta = component.getPriceDelta(
+      {
+        vendor_id: "aws",
+        api_reference: "c7a.large",
+        display_name: "c7a.large",
+        server_id: "srv-1",
+        min_price: 0.12,
+      } as never,
+      "min_price",
+    );
+
+    expect(priceDelta).not.toBeNull();
+    expect(component.getPriceDeltaLabel(priceDelta!)).toBe("+20%");
+  }));
+
   it("renders score, $CORE, and monthly ondemand deltas against the baseline", fakeAsync(() => {
     selectBaselineServer();
     selectFirstAvailableWorkload();

--- a/src/app/pages/advisor/advisor.component.spec.ts
+++ b/src/app/pages/advisor/advisor.component.spec.ts
@@ -1923,6 +1923,9 @@ describe("AdvisorComponent", () => {
   }));
 
   it("uses selected baseline recommendation monthly price for monthly deltas when baseline monthly records are missing", fakeAsync(() => {
+    getServerPrices.and.resolveTo({ body: [] });
+    searchServerPrices.and.resolveTo({ body: [] });
+
     selectBaselineServer();
     selectFirstAvailableWorkload();
 
@@ -1932,8 +1935,6 @@ describe("AdvisorComponent", () => {
         (allocation) => allocation.slug === "MONTHLY",
       )!,
     );
-
-    component.baselineServerPrices.set([] as never[]);
 
     component.recommendations.set([
       {

--- a/src/app/pages/advisor/advisor.component.ts
+++ b/src/app/pages/advisor/advisor.component.ts
@@ -2199,7 +2199,7 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
 
       this.baselineAddonPricingRow.set(
         (response?.body ?? []).find(
-          (row) =>
+          (row: ServerPKs) =>
             row.vendor_id === server.vendor_id &&
             row.api_reference === server.api_reference,
         ) ?? null,

--- a/src/app/pages/advisor/advisor.component.ts
+++ b/src/app/pages/advisor/advisor.component.ts
@@ -661,7 +661,8 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
           min_price: addonRow.min_price ?? null,
           min_price_spot: addonRow.min_price_spot ?? null,
           min_price_ondemand: addonRow.min_price_ondemand ?? null,
-          min_price_ondemand_monthly: addonRow.min_price_ondemand_monthly ?? null,
+          min_price_ondemand_monthly:
+            addonRow.min_price_ondemand_monthly ?? null,
         };
       }
 

--- a/src/app/pages/advisor/advisor.component.ts
+++ b/src/app/pages/advisor/advisor.component.ts
@@ -387,6 +387,7 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
   private baselineBenchmarkRequestVersion = 0;
   private baselineRegionRequestVersion = 0;
   private baselinePriceComparisonRequestVersion = 0;
+  private baselineAddonPricingRequestVersion = 0;
   private baselineScoreComparisonRequestVersion = 0;
   private introductionModal: Modal | null = null;
   private hasViewInitialized = signal(false);
@@ -468,6 +469,7 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly isBaselineRegionEnabled = signal(false);
   readonly selectedBaselineVendorRegion = signal<string | null>(null);
   readonly baselineServerPrices = signal<ServerPrice[]>([]);
+  readonly baselineAddonPricingRow = signal<ServerPKs | null>(null);
   readonly baselinePriceComparisonRows = signal<ServerPriceWithPKs[]>([]);
   readonly baselineScoreComparisonRow = signal<Pick<
     ServerPKs,
@@ -653,6 +655,16 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
 
   readonly baselinePriceAggregate = computed<AdvisorBaselinePriceAggregate>(
     () => {
+      const addonRow = this.baselineAddonPricingRow();
+      if (addonRow) {
+        return {
+          min_price: addonRow.min_price ?? null,
+          min_price_spot: addonRow.min_price_spot ?? null,
+          min_price_ondemand: addonRow.min_price_ondemand ?? null,
+          min_price_ondemand_monthly: addonRow.min_price_ondemand_monthly ?? null,
+        };
+      }
+
       const selectedBaselineVendorRegion = this.selectedBaselineVendorRegion();
       const baselinePriceAggregate = this.advisorUi.buildBaselinePriceAggregate(
         this.baselineServerPrices(),
@@ -1192,16 +1204,31 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
     effect(() => {
       const selectedBaselineServer = this.selectedBaselineServer();
       const selectedCurrency = this.selectedCurrency().slug;
+      const query = this.query();
+      const extraStorageSize = query["extra_storage_size"];
+      const extraStorageType = query["extra_storage_type"];
+      const monthlyInboundTraffic = query["monthly_inbound_traffic"];
+      const monthlyOutboundTraffic = query["monthly_outbound_traffic"];
+      void this.isPriceAllocationEnabled();
+      void this.bestPriceAllocation();
+      void this.isBaselineRegionEnabled();
+      void this.selectedBaselineVendorRegion();
 
       if (!selectedBaselineServer) {
         this.baselineServerPrices.set([]);
         this.baselinePriceComparisonRows.set([]);
         this.baselineScoreComparisonRow.set(null);
+        this.baselineAddonPricingRow.set(null);
         this.isLoadingBaselineRegions.set(false);
         this.isBaselineRegionEnabled.set(false);
         this.selectedBaselineVendorRegion.set(null);
         return;
       }
+
+      void extraStorageSize;
+      void extraStorageType;
+      void monthlyInboundTraffic;
+      void monthlyOutboundTraffic;
 
       void this.loadBaselineRegionPrices(
         selectedBaselineServer,
@@ -1211,6 +1238,15 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
         selectedBaselineServer,
         selectedCurrency,
       );
+
+      if (this.hasTrafficStorageRequirements()) {
+        void this.loadBaselineAddonPricing(
+          selectedBaselineServer,
+          selectedCurrency,
+        );
+      } else {
+        this.baselineAddonPricingRow.set(null);
+      }
     });
 
     effect(() => {
@@ -2078,6 +2114,102 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
       if (requestVersion === this.baselineRegionRequestVersion) {
         this.isLoadingBaselineRegions.set(false);
       }
+    }
+  }
+
+  private getPositiveQueryNumber(value: unknown): number | null {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+
+    return null;
+  }
+
+  private hasTrafficStorageRequirements(): boolean {
+    const query = this.query() as Record<string, unknown>;
+
+    return [
+      query["extra_storage_size"],
+      query["monthly_inbound_traffic"],
+      query["monthly_outbound_traffic"],
+    ].some((value) => this.getPositiveQueryNumber(value) !== null);
+  }
+
+  private async loadBaselineAddonPricing(
+    server: AdvisorBaselineServer,
+    currency: string,
+  ): Promise<void> {
+    const requestVersion = ++this.baselineAddonPricingRequestVersion;
+    const sharedQuery = this.query() as SearchServersServersGetParams;
+    const query: SearchServersServersGetParams = {
+      partial_name_or_id: server.api_reference,
+      vendor: server.vendor_id as SearchServersServersGetParams["vendor"],
+      only_active: true,
+      limit: 100,
+    };
+
+    for (const key of [
+      "extra_storage_size",
+      "monthly_inbound_traffic",
+      "monthly_outbound_traffic",
+    ] as const) {
+      const value = this.getPositiveQueryNumber(sharedQuery[key]);
+
+      if (value !== null) {
+        query[key] = value;
+      }
+    }
+
+    if (sharedQuery.extra_storage_type) {
+      query.extra_storage_type = sharedQuery.extra_storage_type;
+    }
+
+    if (currency !== "USD") {
+      query.currency = currency;
+    }
+
+    if (
+      this.isPriceAllocationEnabled() &&
+      this.bestPriceAllocation().slug !== "ANY"
+    ) {
+      query.best_price_allocation = this.bestPriceAllocation().slug;
+    }
+
+    const baselineRegion = this.selectedBaselineVendorRegion();
+
+    if (this.isBaselineRegionEnabled() && baselineRegion) {
+      query.vendor_regions =
+        baselineRegion as SearchServersServersGetParams["vendor_regions"];
+    }
+
+    try {
+      const response = await this.keeperApi.searchServers(query);
+
+      if (requestVersion !== this.baselineAddonPricingRequestVersion) {
+        return;
+      }
+
+      this.baselineAddonPricingRow.set(
+        (response?.body ?? []).find(
+          (row) =>
+            row.vendor_id === server.vendor_id &&
+            row.api_reference === server.api_reference,
+        ) ?? null,
+      );
+    } catch {
+      if (requestVersion !== this.baselineAddonPricingRequestVersion) {
+        return;
+      }
+
+      this.baselineAddonPricingRow.set(null);
     }
   }
 

--- a/src/app/pages/advisor/advisor.component.ts
+++ b/src/app/pages/advisor/advisor.component.ts
@@ -656,7 +656,7 @@ export class AdvisorComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly baselinePriceAggregate = computed<AdvisorBaselinePriceAggregate>(
     () => {
       const addonRow = this.baselineAddonPricingRow();
-      if (addonRow) {
+      if (this.hasTrafficStorageRequirements() && addonRow) {
         return {
           min_price: addonRow.min_price ?? null,
           min_price_spot: addonRow.min_price_spot ?? null,


### PR DESCRIPTION
# Overview

This fixed the issue for me with the denominator when calculating percentage diff of best price(s) from the baseline server, see e.g. https://sparecores.com/advisor?vendor=azure,gcp,aws&monthly_outbound_traffic=2000&extra_storage_size=100&baseline_vendor=aws&baseline_server=m5.2xlarge&limit_architecture=true&workload_id=redis:rps-extrapolated&workload_config={%22operation%22:%20%22SET%22,%20%22pipeline%22:%2016.0}&avg_cpu_utilization=90&minimum_memory=24&limit=250&price_allocation_enabled=true&best_price_allocation=MONTHLY&columns=75662352

Please take over for productionalization.

## Required checks

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

Required checks before asking for human review:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and brief description or reference to the relevant issue with details
- [ ] All PR builders passed (linter, unit tests, e2e tests, visual regression tests)
- [ ] Manual testing of new features or bugfixes along with affected pages or components
- [ ] Redundant AI comments, unwanted complexity, and unintentional drifts cleaned up

Further required checks after all other major items in this list are completed:

- [ ] No red flags from coderabbit.ai
- [x] Human approval
